### PR TITLE
FIX: fixed the analogs/points sampling rate comparison

### DIFF
--- a/kineticstoolkit/files.py
+++ b/kineticstoolkit/files.py
@@ -848,7 +848,7 @@ def write_c3d(
         analog_rate = analogs.get_sample_rate()
 
         rate_ratio = analog_rate / point_rate
-        if ~np.isclose(rate_ratio, int(rate_ratio)):
+        if ~np.isclose(rate_ratio, round(rate_ratio)):
             raise ValueError(
                 "The sample rate of analogs must be an integer "
                 "multiple of the points sample rate."


### PR DESCRIPTION
Replaced int(rate_ratio) with round(rate_ratio). The problem with int is that it always rounds down, e.g. int(2.99) will return 2.